### PR TITLE
Wishlist optional sections

### DIFF
--- a/src/pages/wishlist.astro
+++ b/src/pages/wishlist.astro
@@ -19,48 +19,7 @@ const isSection = (entry: WishlistEntry): entry is WishlistSection => {
   return 'section' in entry;
 };
 
-const wishlist: WishlistEntry[] = [
-  {
-    title: "Standalone Item Example",
-    description: "This is a standalone item without a section",
-    links: [{ title: "Example Link", url: "https://example.com" }]
-  },
-  {
-    section: "Electronics",
-    items: [
-      {
-        title: "Mechanical Keyboard",
-        description: "A nice mechanical keyboard with Cherry MX switches",
-        links: [
-          { title: "Amazon", url: "https://amazon.com" },
-          { title: "Manufacturer", url: "https://example.com" }
-        ]
-      },
-      {
-        title: "USB-C Hub",
-        description: "Multi-port hub for laptop connectivity"
-      }
-    ]
-  },
-  {
-    section: "Books",
-    items: [
-      {
-        title: "Design Patterns",
-        description: "Classic software engineering book"
-      },
-      {
-        title: "The Pragmatic Programmer",
-        description: "Tips and techniques for modern software development",
-        links: [{ title: "Bookshop", url: "https://bookshop.org" }]
-      }
-    ]
-  },
-  {
-    title: "Another Standalone Item",
-    description: "Items can appear anywhere in the list, not just at the top"
-  }
-];
+const wishlist: WishlistEntry[] = [];
 ---
 
 <Default>

--- a/src/pages/wishlist.astro
+++ b/src/pages/wishlist.astro
@@ -19,7 +19,48 @@ const isSection = (entry: WishlistEntry): entry is WishlistSection => {
   return 'section' in entry;
 };
 
-const wishlist: WishlistEntry[] = [];
+const wishlist: WishlistEntry[] = [
+  {
+    title: "Standalone Item Example",
+    description: "This is a standalone item without a section",
+    links: [{ title: "Example Link", url: "https://example.com" }]
+  },
+  {
+    section: "Electronics",
+    items: [
+      {
+        title: "Mechanical Keyboard",
+        description: "A nice mechanical keyboard with Cherry MX switches",
+        links: [
+          { title: "Amazon", url: "https://amazon.com" },
+          { title: "Manufacturer", url: "https://example.com" }
+        ]
+      },
+      {
+        title: "USB-C Hub",
+        description: "Multi-port hub for laptop connectivity"
+      }
+    ]
+  },
+  {
+    section: "Books",
+    items: [
+      {
+        title: "Design Patterns",
+        description: "Classic software engineering book"
+      },
+      {
+        title: "The Pragmatic Programmer",
+        description: "Tips and techniques for modern software development",
+        links: [{ title: "Bookshop", url: "https://bookshop.org" }]
+      }
+    ]
+  },
+  {
+    title: "Another Standalone Item",
+    description: "Items can appear anywhere in the list, not just at the top"
+  }
+];
 ---
 
 <Default>

--- a/src/pages/wishlist.astro
+++ b/src/pages/wishlist.astro
@@ -71,12 +71,37 @@ const wishlist: WishlistEntry[] = [
   </section>
   <main>
     {
-      wishlist.map((entry) =>
-        isSection(entry) ? (
+      wishlist.filter(isSection).map((entry) => (
+        <section class="wishlist-section">
+          <h3>{entry.section}</h3>
+          <ul class="wishlist">
+            {entry.items.map((item) => (
+              <li class="wishlist-item">
+                <strong>{item.title}</strong>
+                <p>{item.description}</p>
+                {item.links && item.links.length > 0 && (
+                  <ul class="wishlist-links">
+                    {item.links.map((link) => (
+                      <li>
+                        <a href={link.url}>{link.title}</a>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))
+    }
+    {
+      (() => {
+        const miscItems = wishlist.filter((entry): entry is WishlistItem => !isSection(entry));
+        return miscItems.length > 0 && (
           <section class="wishlist-section">
-            <h3>{entry.section}</h3>
+            <h3>Misc</h3>
             <ul class="wishlist">
-              {entry.items.map((item) => (
+              {miscItems.map((item) => (
                 <li class="wishlist-item">
                   <strong>{item.title}</strong>
                   <p>{item.description}</p>
@@ -93,24 +118,8 @@ const wishlist: WishlistEntry[] = [
               ))}
             </ul>
           </section>
-        ) : (
-          <ul class="wishlist wishlist-standalone">
-            <li class="wishlist-item">
-              <strong>{entry.title}</strong>
-              <p>{entry.description}</p>
-              {entry.links && entry.links.length > 0 && (
-                <ul class="wishlist-links">
-                  {entry.links.map((link) => (
-                    <li>
-                      <a href={link.url}>{link.title}</a>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </li>
-          </ul>
-        )
-      )
+        );
+      })()
     }
   </main>
 </Default>
@@ -135,10 +144,6 @@ const wishlist: WishlistEntry[] = [
     list-style: none;
     padding: 0;
     margin: 0;
-  }
-
-  .wishlist-standalone {
-    margin-block-start: 16px;
   }
 
   .wishlist-item {

--- a/src/pages/wishlist.astro
+++ b/src/pages/wishlist.astro
@@ -126,7 +126,7 @@ const wishlist: WishlistEntry[] = [
 
   .wishlist-section h3 {
     margin-block-end: 12px;
-    font-size: 1.1em;
+    font-size: 1.4em;
     font-weight: 600;
     opacity: 0.9;
   }

--- a/src/pages/wishlist.astro
+++ b/src/pages/wishlist.astro
@@ -122,11 +122,69 @@ const wishlist: WishlistEntry[] = [
       })()
     }
   </main>
+
+  <section class="example-section">
+    <h2>Unfiltered List (Original Order)</h2>
+    <p>This shows the wishlist in the order it was defined, without splitting sections from standalone items.</p>
+  </section>
+  <main>
+    {
+      wishlist.map((entry) =>
+        isSection(entry) ? (
+          <section class="wishlist-section">
+            <h3>{entry.section}</h3>
+            <ul class="wishlist">
+              {entry.items.map((item) => (
+                <li class="wishlist-item">
+                  <strong>{item.title}</strong>
+                  <p>{item.description}</p>
+                  {item.links && item.links.length > 0 && (
+                    <ul class="wishlist-links">
+                      {item.links.map((link) => (
+                        <li>
+                          <a href={link.url}>{link.title}</a>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : (
+          <section class="wishlist-section">
+            <h3>—</h3>
+            <ul class="wishlist">
+              <li class="wishlist-item">
+                <strong>{entry.title}</strong>
+                <p>{entry.description}</p>
+                {entry.links && entry.links.length > 0 && (
+                  <ul class="wishlist-links">
+                    {entry.links.map((link) => (
+                      <li>
+                        <a href={link.url}>{link.title}</a>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            </ul>
+          </section>
+        )
+      )
+    }
+  </main>
 </Default>
 
 <style>
   h2 {
     margin-block-end: 8px;
+  }
+
+  .example-section {
+    margin-block-start: 48px;
+    padding-block-start: 24px;
+    border-top: 2px solid color-mix(in srgb, currentColor 30%, transparent);
   }
 
   .wishlist-section {

--- a/src/pages/wishlist.astro
+++ b/src/pages/wishlist.astro
@@ -2,11 +2,24 @@
 import Header from '@components/header.astro';
 import Default from '@layouts/default.astro';
 
-const wishlistItems: {
+type WishlistItem = {
   title: string;
   description: string;
   links?: { title: string; url: string }[];
-}[] = [];
+};
+
+type WishlistSection = {
+  section: string;
+  items: WishlistItem[];
+};
+
+type WishlistEntry = WishlistItem | WishlistSection;
+
+const isSection = (entry: WishlistEntry): entry is WishlistSection => {
+  return 'section' in entry;
+};
+
+const wishlist: WishlistEntry[] = [];
 ---
 
 <Default>
@@ -16,25 +29,48 @@ const wishlistItems: {
     <p>Things and stuff</p>
   </section>
   <main>
-    <ul class="wishlist">
-      {
-        wishlistItems.map((item) => (
-          <li class="wishlist-item">
-            <strong>{item.title}</strong>
-            <p>{item.description}</p>
-            {item.links && item.links.length > 0 && (
-              <ul class="wishlist-links">
-                {item.links.map((link) => (
-                  <li>
-                    <a href={link.url}>{link.title}</a>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </li>
-        ))
-      }
-    </ul>
+    {
+      wishlist.map((entry) =>
+        isSection(entry) ? (
+          <section class="wishlist-section">
+            <h3>{entry.section}</h3>
+            <ul class="wishlist">
+              {entry.items.map((item) => (
+                <li class="wishlist-item">
+                  <strong>{item.title}</strong>
+                  <p>{item.description}</p>
+                  {item.links && item.links.length > 0 && (
+                    <ul class="wishlist-links">
+                      {item.links.map((link) => (
+                        <li>
+                          <a href={link.url}>{link.title}</a>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : (
+          <ul class="wishlist wishlist-standalone">
+            <li class="wishlist-item">
+              <strong>{entry.title}</strong>
+              <p>{entry.description}</p>
+              {entry.links && entry.links.length > 0 && (
+                <ul class="wishlist-links">
+                  {entry.links.map((link) => (
+                    <li>
+                      <a href={link.url}>{link.title}</a>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          </ul>
+        )
+      )
+    }
   </main>
 </Default>
 
@@ -43,9 +79,24 @@ const wishlistItems: {
     margin-block-end: 8px;
   }
 
+  .wishlist-section {
+    margin-block-start: 24px;
+  }
+
+  .wishlist-section h3 {
+    margin-block-end: 12px;
+    font-size: 1.1em;
+    font-weight: 600;
+    opacity: 0.9;
+  }
+
   .wishlist {
     list-style: none;
     padding: 0;
+    margin: 0;
+  }
+
+  .wishlist-standalone {
     margin-block-start: 16px;
   }
 

--- a/src/pages/wishlist.astro
+++ b/src/pages/wishlist.astro
@@ -146,16 +146,22 @@ const wishlist: WishlistEntry[] = [
     margin: 0;
   }
 
-  .wishlist-item {
-    margin-block-end: 24px;
+  .wishlist-section {
     padding-block-end: 24px;
     border-bottom: 1px solid color-mix(in srgb, currentColor 20%, transparent);
   }
 
-  .wishlist-item:last-child {
+  .wishlist-section:last-child {
     border-bottom: none;
-    margin-block-end: 0;
     padding-block-end: 0;
+  }
+
+  .wishlist-item {
+    margin-block-end: 16px;
+  }
+
+  .wishlist-item:last-child {
+    margin-block-end: 0;
   }
 
   .wishlist-item strong {

--- a/src/pages/wishlist.astro
+++ b/src/pages/wishlist.astro
@@ -122,69 +122,11 @@ const wishlist: WishlistEntry[] = [
       })()
     }
   </main>
-
-  <section class="example-section">
-    <h2>Unfiltered List (Original Order)</h2>
-    <p>This shows the wishlist in the order it was defined, without splitting sections from standalone items.</p>
-  </section>
-  <main>
-    {
-      wishlist.map((entry) =>
-        isSection(entry) ? (
-          <section class="wishlist-section">
-            <h3>{entry.section}</h3>
-            <ul class="wishlist">
-              {entry.items.map((item) => (
-                <li class="wishlist-item">
-                  <strong>{item.title}</strong>
-                  <p>{item.description}</p>
-                  {item.links && item.links.length > 0 && (
-                    <ul class="wishlist-links">
-                      {item.links.map((link) => (
-                        <li>
-                          <a href={link.url}>{link.title}</a>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </section>
-        ) : (
-          <section class="wishlist-section">
-            <h3>—</h3>
-            <ul class="wishlist">
-              <li class="wishlist-item">
-                <strong>{entry.title}</strong>
-                <p>{entry.description}</p>
-                {entry.links && entry.links.length > 0 && (
-                  <ul class="wishlist-links">
-                    {entry.links.map((link) => (
-                      <li>
-                        <a href={link.url}>{link.title}</a>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </li>
-            </ul>
-          </section>
-        )
-      )
-    }
-  </main>
 </Default>
 
 <style>
   h2 {
     margin-block-end: 8px;
-  }
-
-  .example-section {
-    margin-block-start: 48px;
-    padding-block-start: 24px;
-    border-top: 2px solid color-mix(in srgb, currentColor 30%, transparent);
   }
 
   .wishlist-section {

--- a/src/pages/wishlist.astro
+++ b/src/pages/wishlist.astro
@@ -142,8 +142,8 @@ const wishlist: WishlistEntry[] = [
   }
 
   .wishlist-item {
-    margin-block-end: 16px;
-    padding-block-end: 16px;
+    margin-block-end: 24px;
+    padding-block-end: 24px;
     border-bottom: 1px solid color-mix(in srgb, currentColor 20%, transparent);
   }
 


### PR DESCRIPTION
Update wishlist schema and layout to support optional sections or standalone items.

The previous wishlist only supported a flat list of items. This PR introduces a new schema that allows for `WishlistSection` (grouping items under a title) and `WishlistItem` (standalone items), unified by a `WishlistEntry` union type. The layout and styling have been updated to render these new structures appropriately, including `<h3>` headers for sections and distinct styling for standalone items.

---
<a href="https://cursor.com/background-agent?bcId=bc-491d2286-511b-4a76-aa81-caf72e8ef5a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-491d2286-511b-4a76-aa81-caf72e8ef5a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

